### PR TITLE
Set !default flag for $grid-width

### DIFF
--- a/scss/mixins/_settings.global.scss
+++ b/scss/mixins/_settings.global.scss
@@ -57,7 +57,7 @@ $grid-widths: (
   90: 9 / 10,
   95: 95 / 100,
   100: 1
-);
+) !default;
 
 //
 // Colors


### PR DESCRIPTION
Currently it's not possible to apply custom grid-widths, because the mixin imports the _settings.global.scss. This can be solved by adding a !default flag.