### PR TITLE
c-text--help: reset default abbr style

### DIFF
--- a/scss/components.typography.scss
+++ b/scss/components.typography.scss
@@ -25,6 +25,7 @@
 
 .c-text--help[title] {
   border-bottom: $help-border-bottom;
+  text-decoration: none;
   cursor: help;
 }
 


### PR DESCRIPTION
[mdn link](https://developer.mozilla.org/en-US/docs/Styling_Abbreviations_and_Acronyms)