### PR TITLE
Rename sizing utility class

### DIFF
--- a/scss/utilities.boxing.scss
+++ b/scss/utilities.boxing.scss
@@ -4,98 +4,98 @@
   @include no-overflow;
 }
 
-.u-letter-box--super {
+.u-letter-box-super {
   @include letter-box--super;
 }
 
-.u-letter-box--xlarge {
+.u-letter-box-xlarge {
   @include letter-box--xlarge;
 }
 
-.u-letter-box--large {
+.u-letter-box-large {
   @include letter-box--large;
 }
 
-.u-letter-box--medium {
+.u-letter-box-medium {
   @include letter-box--medium;
 }
 
-.u-letter-box--small {
+.u-letter-box-small {
   @include letter-box--small;
 }
 
-.u-letter-box--xsmall {
+.u-letter-box-xsmall {
   @include letter-box--xsmall;
 }
 
-.u-letter-box--tiny {
+.u-letter-box-tiny {
   @include letter-box--tiny;
 }
 
-.u-letter-box--none {
+.u-letter-box-none {
   @include letter-box--none;
 }
 
-.u-pillar-box--super {
+.u-pillar-box-super {
   @include pillar-box--super;
 }
 
-.u-pillar-box--xlarge {
+.u-pillar-box-xlarge {
   @include pillar-box--xlarge;
 }
 
-.u-pillar-box--large {
+.u-pillar-box-large {
   @include pillar-box--large;
 }
 
-.u-pillar-box--medium {
+.u-pillar-box-medium {
   @include pillar-box--medium;
 }
 
-.u-pillar-box--small {
+.u-pillar-box-small {
   @include pillar-box--small;
 }
 
-.u-pillar-box--xsmall {
+.u-pillar-box-xsmall {
   @include pillar-box--xsmall;
 }
 
-.u-pillar-box--tiny {
+.u-pillar-box-tiny {
   @include pillar-box--tiny;
 }
 
-.u-pillar-box--none {
+.u-pillar-box-none {
   @include pillar-box--none;
 }
 
-.u-window-box--super {
+.u-window-box-super {
   @include window-box--super;
 }
 
-.u-window-box--xlarge {
+.u-window-box-xlarge {
   @include window-box--xlarge;
 }
 
-.u-window-box--large {
+.u-window-box-large {
   @include window-box--large;
 }
 
-.u-window-box--medium {
+.u-window-box-medium {
   @include window-box--medium;
 }
 
-.u-window-box--small {
+.u-window-box-small {
   @include window-box--small;
 }
 
-.u-window-box--xsmall {
+.u-window-box-xsmall {
   @include window-box--xsmall;
 }
 
-.u-window-box--tiny {
+.u-window-box-tiny {
   @include window-box--tiny;
 }
 
-.u-window-box--none {
+.u-window-box-none {
   @include window-box--none;
 }


### PR DESCRIPTION
Because there is no class named like .u-letter-box, I think that should be a class name that does not use "--".