### PR TITLE
Drawer with dismiss Event

### DIFF
--- a/atoms/src/components/drawer/blaze-drawer.spec.ts
+++ b/atoms/src/components/drawer/blaze-drawer.spec.ts
@@ -80,4 +80,25 @@ describe('Drawer', () => {
     expect(element.isOpen()).toEqual(false);
     expect(element).toMatchSnapshot();
   });
+
+  it('triggers onClose event', async (done) => {
+    const window = new TestWindow();
+    element = await window.load({
+      components: [Drawer],
+      html: `<blaze-drawer open dismissible>default</blaze-drawer>`
+    });
+    window.flush();
+
+    element.addEventListener('onClose', () => {
+      try {
+        expect(element.isOpen()).toBe(false);
+        done();
+      } catch (err) {
+        done.fail(err);
+      }
+    });
+
+    expect(element.isOpen()).toBe(true);
+    element.querySelector('blaze-overlay').click();
+  });
 });

--- a/atoms/src/components/drawer/blaze-drawer.tsx
+++ b/atoms/src/components/drawer/blaze-drawer.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, Method, State, Element } from '@stencil/core';
+import { Component, Event, EventEmitter, Prop, Method, State, Element } from '@stencil/core';
 
 @Component({
   tag: 'blaze-drawer'
@@ -10,10 +10,12 @@ export class Drawer {
   @Prop() dismissible: boolean = false;
   @Prop() position: string = 'bottom';
   @State() _isOpen: boolean = false;
+  @Event() onClose: EventEmitter;
 
   @Method()
   close() {
     this._isOpen = false;
+    this.onClose.emit();
   }
 
   @Method()


### PR DESCRIPTION
Related to #194 

Had to rename the `dismiss` function to `overlayDismiss` so that it not collides with the event name.