### PR TITLE
New Atom blaze-input-group

### DIFF
--- a/atoms/src/components/inputs/__snapshots__/blaze-input-group.spec.ts.snap
+++ b/atoms/src/components/inputs/__snapshots__/blaze-input-group.spec.ts.snap
@@ -1,0 +1,187 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InputGroup renders an empty input-group 1`] = `
+<blaze-input-group
+  class="hydrated"
+>
+  
+  <div
+    class="c-input-group"
+  >
+    
+  </div>
+</blaze-input-group>
+`;
+
+exports[`InputGroup renders rounded modifier class 1`] = `
+<blaze-input-group
+  class="hydrated"
+  rounded=""
+>
+  
+  
+  
+  
+  
+  
+  
+  
+  <div
+    class="c-input-group c-input-group--rounded"
+  >
+    
+    
+       
+    <button
+      class="c-button c-button--brand"
+    >
+      Action
+    </button>
+    
+       
+    <input
+      class="c-field"
+      type="text"
+    />
+    
+       
+    <button
+      class="c-button c-button--brand"
+    >
+      Action
+    </button>
+    
+     
+  </div>
+</blaze-input-group>
+`;
+
+exports[`InputGroup renders rounded modifier class with edge 1`] = `
+<blaze-input-group
+  class="hydrated"
+  edge="left"
+  rounded=""
+>
+  
+  
+  
+  
+  
+  
+  
+  
+  <div
+    class="c-input-group c-input-group--rounded-left"
+  >
+    
+    
+       
+    <button
+      class="c-button c-button--brand"
+    >
+      Action
+    </button>
+    
+       
+    <input
+      class="c-field"
+      type="text"
+    />
+    
+       
+    <button
+      class="c-button c-button--brand"
+    >
+      Action
+    </button>
+    
+     
+  </div>
+</blaze-input-group>
+`;
+
+exports[`InputGroup renders stacked modifier class 1`] = `
+<blaze-input-group
+  class="hydrated"
+  stacked=""
+>
+  
+  
+  
+  
+  
+  
+  
+  
+  <div
+    class="c-input-group c-input-group--stacked"
+  >
+    
+    
+       
+    <button
+      class="c-button c-button--brand"
+    >
+      Action
+    </button>
+    
+       
+    <input
+      class="c-field"
+      type="text"
+    />
+    
+       
+    <button
+      class="c-button c-button--brand"
+    >
+      Action
+    </button>
+    
+     
+  </div>
+</blaze-input-group>
+`;
+
+exports[`InputGroup renders with different tag 1`] = `
+<blaze-input-group
+  class="hydrated"
+  tag="span"
+>
+  
+  
+  
+  
+  
+  
+  
+  
+  <span
+    class="c-input-group"
+  >
+    
+    
+       
+    <button
+      class="c-button c-button--brand"
+    >
+      Action
+    </button>
+    
+       
+    <input
+      class="c-field"
+      type="text"
+    />
+    
+       
+    <button
+      class="c-button c-button--brand"
+    >
+      Action
+    </button>
+    
+     
+  </span>
+</blaze-input-group>
+`;

--- a/atoms/src/components/inputs/blaze-input-group.spec.ts
+++ b/atoms/src/components/inputs/blaze-input-group.spec.ts
@@ -1,0 +1,66 @@
+import { TestWindow } from '@stencil/core/testing';
+import { InputGroup } from './blaze-input-group';
+
+describe('InputGroup', () => {
+  it('should build', () => {
+    expect(new InputGroup()).toBeTruthy();
+  });
+
+  describe('renders', () => {
+    let element;
+
+    const snapIt = (name, html) => {
+      it(name, async () => {
+        const window = new TestWindow();
+        element = await window.load({
+          components: [InputGroup],
+          html
+        });
+        window.flush();
+
+        expect(element).toMatchSnapshot();
+      });
+    };
+
+    snapIt(
+      'an empty input-group',
+      '<blaze-input-group></blaze-input-group>'
+    );
+
+    snapIt(
+      'with different tag',
+      `<blaze-input-group tag="span">
+       <button class="c-button c-button--brand">Action</button>
+       <input type="text" class="c-field">
+       <button class="c-button c-button--brand">Action</button>
+     </blaze-input-group>`
+    );
+
+    snapIt(
+      'stacked modifier class',
+      `<blaze-input-group stacked>
+       <button class="c-button c-button--brand">Action</button>
+       <input type="text" class="c-field">
+       <button class="c-button c-button--brand">Action</button>
+     </blaze-input-group>`
+    );
+
+    snapIt(
+      'rounded modifier class',
+      `<blaze-input-group rounded>
+       <button class="c-button c-button--brand">Action</button>
+       <input type="text" class="c-field">
+       <button class="c-button c-button--brand">Action</button>
+     </blaze-input-group>`
+    );
+
+    snapIt(
+      'rounded modifier class with edge',
+      `<blaze-input-group rounded edge="left">
+       <button class="c-button c-button--brand">Action</button>
+       <input type="text" class="c-field">
+       <button class="c-button c-button--brand">Action</button>
+     </blaze-input-group>`
+    );
+  });
+});

--- a/atoms/src/components/inputs/blaze-input-group.tsx
+++ b/atoms/src/components/inputs/blaze-input-group.tsx
@@ -1,0 +1,28 @@
+import { Component, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'blaze-input-group'
+})
+export class InputGroup {
+
+  @Prop() tag: string = 'div';
+  @Prop() stacked: boolean;
+  @Prop() rounded: boolean;
+  @Prop() edge: string;
+
+  render() {
+    const Tag = this.tag;
+    const stackedClass = this.stacked ? `c-input-group--stacked` : '';
+
+    let roundedClass = this.rounded ? `c-input-group--rounded` : '';
+    if (this.rounded && this.edge) {
+      roundedClass += `-${this.edge}`;
+    }
+
+    return (
+      <Tag class={`c-input-group ${stackedClass} ${roundedClass}`}>
+        <slot />
+      </Tag>
+    );
+  }
+}

--- a/atoms/src/index.html
+++ b/atoms/src/index.html
@@ -225,6 +225,37 @@
         <blaze-image user="martinjphoto" width="1024" height="768" filter="mountains" likes></blaze-image>
       </blaze-tab>
 
+      <blaze-tab header="Inputs">
+        <h2>Input Groups</h2>
+        <h3>Stacked</h3>
+        <blaze-input-group stacked>
+          <button class="c-button c-button--brand">Action</button>
+          <input type="text" class="c-field" placeholder="Text Input">
+          <button class="c-button c-button--brand">Action</button>
+        </blaze-input-group>
+
+        <h3>Rounded</h3>
+        <blaze-input-group rounded>
+          <button class="c-button c-button--brand">Action</button>
+          <input type="text" class="c-field" placeholder="Text Input">
+          <button class="c-button c-button--brand">Action</button>
+        </blaze-input-group>
+
+        <h3>Rounded Left</h3>
+        <blaze-input-group rounded edge="left">
+          <button class="c-button c-button--brand">Action</button>
+          <input type="text" class="c-field" placeholder="Text Input">
+          <button class="c-button c-button--brand">Action</button>
+        </blaze-input-group>
+
+        <h3>Rounded Right</h3>
+        <blaze-input-group rounded edge="right">
+          <button class="c-button c-button--brand">Action</button>
+          <input type="text" class="c-field" placeholder="Text Input">
+          <button class="c-button c-button--brand">Action</button>
+        </blaze-input-group>
+      </blaze-tab>
+
       <blaze-tab header="Modals">
         <button type="button" onclick="javascript:showModal('#modal-dismissible')" class="c-button c-button--brand">Open dismissible Modal</button>
         <blaze-modal dismissible id="modal-dismissible">


### PR DESCRIPTION
That's for the `c-input-group`.

An extra atom for `c-field` would be no use because of all the different HTML tags it applies to.
But the container classes like `o-field o-fieldset o-form-element` can be easily "atomized".