### PR TITLE
New Atom blaze-button

### DIFF
--- a/atoms/src/components/button/__snapshots__/blaze-button.spec.ts.snap
+++ b/atoms/src/components/button/__snapshots__/blaze-button.spec.ts.snap
@@ -1,0 +1,163 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button renders a colored button 1`] = `
+<blaze-button
+  class="hydrated"
+  type="info"
+>
+  
+  
+  <button
+    class="c-button c-button--info"
+  >
+    
+    Action
+  </button>
+</blaze-button>
+`;
+
+exports[`Button renders a colored ghost button 1`] = `
+<blaze-button
+  class="hydrated"
+  ghost=""
+  type="info"
+>
+  
+  
+  <button
+    class="c-button c-button--ghost-info"
+  >
+    
+    Action
+  </button>
+</blaze-button>
+`;
+
+exports[`Button renders a default button 1`] = `
+<blaze-button
+  class="hydrated"
+>
+  
+  
+  <button
+    class="c-button"
+  >
+    
+    Action
+  </button>
+</blaze-button>
+`;
+
+exports[`Button renders a full-width button 1`] = `
+<blaze-button
+  class="hydrated"
+  full=""
+>
+  
+  
+  <button
+    class="c-button c-button--block"
+  >
+    
+    Action
+  </button>
+</blaze-button>
+`;
+
+exports[`Button renders a ghost button 1`] = `
+<blaze-button
+  class="hydrated"
+  ghost=""
+>
+  
+  
+  <button
+    class="c-button c-button--ghost"
+  >
+    
+    Action
+  </button>
+</blaze-button>
+`;
+
+exports[`Button renders a rounded button 1`] = `
+<blaze-button
+  class="hydrated"
+  rounded=""
+>
+  
+  
+  <button
+    class="c-button c-button--rounded"
+  >
+    
+    Action
+  </button>
+</blaze-button>
+`;
+
+exports[`Button renders a rounded ghost button 1`] = `
+<blaze-button
+  class="hydrated"
+  ghost=""
+  rounded=""
+>
+  
+  
+  <button
+    class="c-button c-button--ghost c-button--rounded"
+  >
+    
+    Action
+  </button>
+</blaze-button>
+`;
+
+exports[`Button renders a sized button 1`] = `
+<blaze-button
+  class="hydrated"
+  size="small"
+>
+  
+  
+  <button
+    class="c-button u-small"
+  >
+    
+    Action
+  </button>
+</blaze-button>
+`;
+
+exports[`Button renders an active button 1`] = `
+<blaze-button
+  active=""
+  class="hydrated"
+>
+  
+  
+  <button
+    class="c-button c-button--active"
+  >
+    
+    Action
+  </button>
+</blaze-button>
+`;
+
+exports[`Button renders an input button 1`] = `
+<blaze-button
+  class="hydrated"
+  tag="input"
+  value="Action"
+>
+  
+  <input
+    class="c-button"
+    type="button"
+    value="Action"
+  >
+    
+  </input>
+</blaze-button>
+`;

--- a/atoms/src/components/button/__snapshots__/blaze-button.spec.ts.snap
+++ b/atoms/src/components/button/__snapshots__/blaze-button.spec.ts.snap
@@ -129,6 +129,22 @@ exports[`Button renders a sized button 1`] = `
 </blaze-button>
 `;
 
+exports[`Button renders an a button 1`] = `
+<blaze-button
+  class="hydrated"
+  href="#"
+  value="Action"
+>
+  
+  <a
+    class="c-button"
+    href="#"
+  >
+    
+  </a>
+</blaze-button>
+`;
+
 exports[`Button renders an active button 1`] = `
 <blaze-button
   active=""
@@ -142,22 +158,5 @@ exports[`Button renders an active button 1`] = `
     
     Action
   </button>
-</blaze-button>
-`;
-
-exports[`Button renders an input button 1`] = `
-<blaze-button
-  class="hydrated"
-  tag="input"
-  value="Action"
->
-  
-  <input
-    class="c-button"
-    type="button"
-    value="Action"
-  >
-    
-  </input>
 </blaze-button>
 `;

--- a/atoms/src/components/button/blaze-button.spec.ts
+++ b/atoms/src/components/button/blaze-button.spec.ts
@@ -28,8 +28,8 @@ describe('Button', () => {
     );
 
     snapIt(
-      'an input button',
-      `<blaze-button tag="input" value="Action"></blaze-button>`
+      'an a button',
+      `<blaze-button href="#" value="Action"></blaze-button>`
     );
 
     snapIt(

--- a/atoms/src/components/button/blaze-button.spec.ts
+++ b/atoms/src/components/button/blaze-button.spec.ts
@@ -1,0 +1,75 @@
+import { TestWindow } from '@stencil/core/testing';
+import { Button } from './blaze-button';
+
+describe('Button', () => {
+  it('should build', () => {
+    expect(new Button()).toBeTruthy();
+  });
+
+  describe('renders', () => {
+    let element;
+
+    const snapIt = (name, html) => {
+      it(name, async () => {
+        const window = new TestWindow();
+        element = await window.load({
+          components: [Button],
+          html
+        });
+        window.flush();
+
+        expect(element).toMatchSnapshot();
+      });
+    };
+
+    snapIt(
+      'a default button',
+      `<blaze-button>Action</blaze-button>`
+    );
+
+    snapIt(
+      'an input button',
+      `<blaze-button tag="input" value="Action"></blaze-button>`
+    );
+
+    snapIt(
+      'a colored button',
+      `<blaze-button type="info">Action</blaze-button>`
+    );
+
+    snapIt(
+      'a sized button',
+      `<blaze-button size="small">Action</blaze-button>`
+    );
+
+    snapIt(
+      'a full-width button',
+      `<blaze-button full>Action</blaze-button>`
+    );
+
+    snapIt(
+      'a ghost button',
+      `<blaze-button ghost>Action</blaze-button>`
+    );
+
+    snapIt(
+      'a colored ghost button',
+      `<blaze-button ghost type="info">Action</blaze-button>`
+    );
+
+    snapIt(
+      'a rounded button',
+      `<blaze-button rounded>Action</blaze-button>`
+    );
+
+    snapIt(
+      'a rounded ghost button',
+      `<blaze-button rounded ghost>Action</blaze-button>`
+    );
+
+    snapIt(
+      'an active button',
+      `<blaze-button active>Action</blaze-button>`
+    );
+  });
+});

--- a/atoms/src/components/button/blaze-button.tsx
+++ b/atoms/src/components/button/blaze-button.tsx
@@ -1,17 +1,17 @@
-import { Component, Element, Prop } from '@stencil/core';
+import { Component, Prop } from '@stencil/core';
 
 @Component({
   tag: 'blaze-button'
 })
 export class Button {
 
-  @Element() private element: HTMLElement;
   @Prop() type: string;
   @Prop() size: string;
   @Prop() full: boolean;
   @Prop() ghost: boolean;
   @Prop() rounded: boolean;
   @Prop() active: boolean;
+  @Prop() href: string;
 
   render() {
     const sizeClass = this.size ? `u-${this.size}` : '';
@@ -26,22 +26,20 @@ export class Button {
       ghostClass += `-${this.type}`;
     }
 
-    // switch HTML tag to "a" if "href" is specified
-    let Tag = 'button';
-    let aAtts = {};
-    const attributes: any = this.element.attributes;
-    if (attributes.hasOwnProperty('href')) {
-      Tag = 'a';
-      aAtts = {
-        href: attributes.href.value || '',
-      };
+    const cssClasses = `c-button ${typeClass} ${sizeClass} ${fullClass} ${ghostClass} ${roundedClass} ${activeClass}`;
+
+    if (this.href) {
+      return (
+        <a href={this.href} class={cssClasses}>
+          <slot />
+        </a>
+      );
     }
 
     return (
-      <Tag class={`c-button ${typeClass} ${sizeClass} ${fullClass} ${ghostClass} ${roundedClass} ${activeClass}`}
-           {...aAtts}>
+      <button class={cssClasses}>
         <slot />
-      </Tag>
+      </button>
     );
   }
 }

--- a/atoms/src/components/button/blaze-button.tsx
+++ b/atoms/src/components/button/blaze-button.tsx
@@ -1,0 +1,49 @@
+import { Component, Element, Prop } from '@stencil/core';
+
+@Component({
+  tag: 'blaze-button'
+})
+export class Button {
+
+  @Element() private element: HTMLElement;
+  @Prop() tag: string = 'button';
+  @Prop() type: string;
+  @Prop() size: string;
+  @Prop() full: boolean;
+  @Prop() ghost: boolean;
+  @Prop() rounded: boolean;
+  @Prop() active: boolean;
+
+  render() {
+    const Tag = this.tag;
+    const sizeClass = this.size ? `u-${this.size}` : '';
+    const fullClass = this.full ? `c-button--block` : '';
+    const roundedClass = this.rounded ? `c-button--rounded` : '';
+    const activeClass = this.active ? `c-button--active` : '';
+
+    let typeClass = this.type ? `c-button--${this.type}` : '';
+    let ghostClass = this.ghost ? `c-button--ghost` : '';
+    if (this.ghost && this.type) {
+      typeClass = '';
+      ghostClass += `-${this.type}`;
+    }
+
+    // in case of tag="input"
+    let inputAtts = {};
+    if (this.tag === 'input') {
+      const attributes: any = this.element.attributes;
+      inputAtts = {
+        type: (attributes.inputType ? attributes.inputType.value : false) || 'button',
+        value: attributes.value.value,
+      };
+    }
+
+    return (
+      <Tag class={`c-button ${typeClass} ${sizeClass} ${fullClass} ${ghostClass} ${roundedClass} ${activeClass}`}
+           {...inputAtts}
+      >
+        <slot />
+      </Tag>
+    );
+  }
+}

--- a/atoms/src/components/button/blaze-button.tsx
+++ b/atoms/src/components/button/blaze-button.tsx
@@ -6,7 +6,6 @@ import { Component, Element, Prop } from '@stencil/core';
 export class Button {
 
   @Element() private element: HTMLElement;
-  @Prop() tag: string = 'button';
   @Prop() type: string;
   @Prop() size: string;
   @Prop() full: boolean;
@@ -15,7 +14,6 @@ export class Button {
   @Prop() active: boolean;
 
   render() {
-    const Tag = this.tag;
     const sizeClass = this.size ? `u-${this.size}` : '';
     const fullClass = this.full ? `c-button--block` : '';
     const roundedClass = this.rounded ? `c-button--rounded` : '';
@@ -28,20 +26,20 @@ export class Button {
       ghostClass += `-${this.type}`;
     }
 
-    // in case of tag="input"
-    let inputAtts = {};
-    if (this.tag === 'input') {
-      const attributes: any = this.element.attributes;
-      inputAtts = {
-        type: (attributes.inputType ? attributes.inputType.value : false) || 'button',
-        value: attributes.value.value,
+    // switch HTML tag to "a" if "href" is specified
+    let Tag = 'button';
+    let aAtts = {};
+    const attributes: any = this.element.attributes;
+    if (attributes.hasOwnProperty('href')) {
+      Tag = 'a';
+      aAtts = {
+        href: attributes.href.value || '',
       };
     }
 
     return (
       <Tag class={`c-button ${typeClass} ${sizeClass} ${fullClass} ${ghostClass} ${roundedClass} ${activeClass}`}
-           {...inputAtts}
-      >
+           {...aAtts}>
         <slot />
       </Tag>
     );

--- a/atoms/src/index.html
+++ b/atoms/src/index.html
@@ -130,6 +130,54 @@
         <blaze-badge ghost rounded type="error">error</blaze-badge>
       </blaze-tab>
 
+      <blaze-tab header="Buttons">
+        <h3>Different Tags</h3>
+        <blaze-button>Action</blaze-button>
+        <blaze-button tag="input" value="Action">Action</blaze-button>
+        <blaze-button tag="a">Action</blaze-button>
+
+        <h3>Colors</h3>
+        <blaze-button type="brand">Action</blaze-button>
+        <blaze-button type="info">Action</blaze-button>
+        <blaze-button type="warning">Action</blaze-button>
+        <blaze-button type="success">Action</blaze-button>
+        <blaze-button type="error">Action</blaze-button>
+
+        <h3>Sizes</h3>
+        <blaze-button size="xsmall">Action</blaze-button>
+        <blaze-button size="small">Action</blaze-button>
+        <blaze-button size="medium">Action</blaze-button>
+        <blaze-button size="large">Action</blaze-button>
+        <blaze-button size="xlarge">Action</blaze-button>
+        <blaze-button size="super">Action</blaze-button>
+
+        <h3>Full Width</h3>
+        <blaze-button full>Action</blaze-button>
+
+        <h3>Ghost</h3>
+        <blaze-button ghost type="brand">Action</blaze-button>
+        <blaze-button ghost type="info">Action</blaze-button>
+        <blaze-button ghost type="warning">Action</blaze-button>
+        <blaze-button ghost type="success">Action</blaze-button>
+        <blaze-button ghost type="error">Action</blaze-button>
+
+        <h3>Rounded</h3>
+        <blaze-button rounded type="brand">Action</blaze-button>
+        <blaze-button rounded type="info">Action</blaze-button>
+        <blaze-button rounded type="warning">Action</blaze-button>
+        <blaze-button rounded type="success">Action</blaze-button>
+        <blaze-button rounded type="error">Action</blaze-button>
+        <blaze-button ghost rounded type="brand">Action</blaze-button>
+        <blaze-button ghost rounded type="info">Action</blaze-button>
+        <blaze-button ghost rounded type="warning">Action</blaze-button>
+        <blaze-button ghost rounded type="success">Action</blaze-button>
+        <blaze-button ghost rounded type="error">Action</blaze-button>
+
+        <h3>Active</h3>
+        <blaze-button active type="info">Action</blaze-button>
+        <blaze-button type="info">Action</blaze-button>
+      </blaze-tab>
+
       <blaze-tab header="Breadcrumbs">
         <blaze-breadcrumbs aria-label="Breadcrumbs">
           <blaze-breadcrumb href="/">Home</blaze-breadcrumb>

--- a/atoms/src/index.html
+++ b/atoms/src/index.html
@@ -134,7 +134,7 @@
         <h3>Different Tags</h3>
         <blaze-button>Action</blaze-button>
         <blaze-button tag="input" value="Action">Action</blaze-button>
-        <blaze-button tag="a">Action</blaze-button>
+        <blaze-button tag="a" href="#">Action</blaze-button>
 
         <h3>Colors</h3>
         <blaze-button type="brand">Action</blaze-button>


### PR DESCRIPTION
Since `c-button` can be applied to `button a input` it was a bit tricky. Maybe we just leave out the possibility for different tags and just go with `button` as the HTML-Tag.

I did catch the case for the `input` with it's special attributes (although not all of them), but for the `a`-tag there should be a way to specify a `href` and maybe other `a`-specific tags as well. But if you really need that then you can add the classes and attributes yourself to just a normal `a` instead of the `blaze-button`.
That's why I figure limiting it to just `button` would be the most sensible.