### PR TITLE
Progress with change and onChange Events

### DIFF
--- a/atoms/src/components/progress/blaze-progress-bar.tsx
+++ b/atoms/src/components/progress/blaze-progress-bar.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop } from '@stencil/core';
+import { Component, Event, EventEmitter, Prop, Watch } from '@stencil/core';
 
 @Component({
   tag: 'blaze-progress-bar'
@@ -9,6 +9,12 @@ export class ProgressBar {
   @Prop() value: number;
   @Prop() min: number = 0;
   @Prop() max: number = 100;
+  @Event() change: EventEmitter;
+
+  @Watch('value')
+  watchValue(value: boolean, oldValue: boolean) {
+    this.change.emit({ value, oldValue });
+  }
 
   render() {
     const typeClass = this.type ? `c-progress__bar--${this.type}` : '';

--- a/atoms/src/components/progress/blaze-progress-bar.tsx
+++ b/atoms/src/components/progress/blaze-progress-bar.tsx
@@ -9,11 +9,11 @@ export class ProgressBar {
   @Prop() value: number;
   @Prop() min: number = 0;
   @Prop() max: number = 100;
-  @Event() change: EventEmitter;
+  @Event() onChangeBar: EventEmitter;
 
   @Watch('value')
   watchValue(value: boolean, oldValue: boolean) {
-    this.change.emit({ value, oldValue });
+    this.onChangeBar.emit({ value, oldValue });
   }
 
   render() {

--- a/atoms/src/components/progress/blaze-progress.spec.ts
+++ b/atoms/src/components/progress/blaze-progress.spec.ts
@@ -1,44 +1,73 @@
 import { TestWindow } from '@stencil/core/testing';
 import { Progress } from './blaze-progress';
+import { ProgressBar } from './blaze-progress-bar';
 
 describe('Progress', () => {
   it('should build', () => {
     expect(new Progress()).toBeTruthy();
+    expect(new ProgressBar()).toBeTruthy();
   });
 
-  let element;
+  describe('renders', () => {
+    let element;
 
-  const snapIt = (name, html) => {
-    it(name, async () => {
-      const window = new TestWindow();
-      element = await window.load({
-        components: [Progress],
-        html
+    const snapIt = (name, html) => {
+      it(name, async () => {
+        const window = new TestWindow();
+        element = await window.load({
+          components: [Progress],
+          html
+        });
+        window.flush();
+
+        expect(element).toMatchSnapshot();
       });
-      window.flush();
+    };
 
-      expect(element).toMatchSnapshot();
+    snapIt(
+      'basic progress bar',
+      '<blaze-progress percentage="5">5%</blaze-progress>'
+    );
+
+    snapIt(
+      'size correctly',
+      '<blaze-progress size="small" percentage="15">15%</blaze-progress>'
+    );
+
+    snapIt(
+      'type correctly',
+      '<blaze-progress size="medium" type="info" percentage="20">20%</blaze-progress>'
+    );
+
+    snapIt(
+      'rounded ends correctly',
+      '<blaze-progress size="large" type="success" percentage="25" rounded>25%</blaze-progress>'
+    );
+  });
+
+  it('triggers onChange event', async (done) => {
+    const window = new TestWindow();
+    const element = await window.load({
+      components: [Progress, ProgressBar],
+      html: `<blaze-progress>
+              <blaze-progress-bar value="30">30</blaze-progress-bar>
+            </blaze-progress>`
     });
-  };
+    window.flush();
 
+    element.addEventListener('onChange', ({ detail }) => {
+      try {
+        expect(detail.value).toBe(40);
+        expect(detail.bar).toEqual(element.querySelector('blaze-progress-bar'));
+        expect(detail.idx).toEqual(0);
+        done();
+      } catch (err) {
+        done.fail(err);
+      }
+    });
 
-  snapIt(
-    'renders basic progress bar',
-    '<blaze-progress percentage="5">5%</blaze-progress>'
-  );
-
-  snapIt(
-    'renders size correctly',
-    '<blaze-progress size="small" percentage="15">15%</blaze-progress>'
-  );
-
-  snapIt(
-    'renders type correctly',
-    '<blaze-progress size="medium" type="info" percentage="20">20%</blaze-progress>'
-  );
-
-  snapIt(
-    'renders rounded ends correctly',
-    '<blaze-progress size="large" type="success" percentage="25" rounded>25%</blaze-progress>'
-  );
+    const progressBar = element.querySelector('blaze-progress-bar');
+    expect(progressBar.value).toEqual(30);
+    progressBar.value = 40;
+  });
 });

--- a/atoms/src/components/progress/blaze-progress.tsx
+++ b/atoms/src/components/progress/blaze-progress.tsx
@@ -10,7 +10,7 @@ export class Progress {
   @Prop() size: string = '';
   @Event() onChange: EventEmitter;
 
-  @Listen('change')
+  @Listen('onChangeBar')
   onChangeBar(ev) {
     const progress = this.element.children[0];
     const value = ev.detail;

--- a/atoms/src/components/progress/blaze-progress.tsx
+++ b/atoms/src/components/progress/blaze-progress.tsx
@@ -1,12 +1,23 @@
-import { Component, Prop } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, Listen, Prop } from '@stencil/core';
 
 @Component({
   tag: 'blaze-progress'
 })
 export class Progress {
 
+  @Element() private element: HTMLElement;
   @Prop() rounded: boolean;
   @Prop() size: string = '';
+  @Event() onChange: EventEmitter;
+
+  @Listen('change')
+  onChangeBar(ev) {
+    const progress = this.element.children[0];
+    const value = ev.detail;
+    const bar = ev.target;
+    const idx = [].indexOf.call(progress.children, bar);
+    this.onChange.emit({ idx, bar, ...value });
+  }
 
   render() {
     const sizeClass = this.size ? `u-${this.size}` : '';


### PR DESCRIPTION
Related to #194 

I'm so unsure how to name the events. The most time you'll probably bind the eventListener to the actual `progress-bar` than to the wrapping `progress`.
So I figured instead of my first solution where I called the `progress` change event `onChange` and the `progress-bar` change event `onChangeBar` like with the `accordion`,
I named them like they are now with the `progress` change event still `onChange` but the `progress-bar` change as just `change`.
I dunno. 😰