### PR TITLE
Updated Atom blaze-overlay with modifiers and methods

### DIFF
--- a/atoms/src/components/overlay/blaze-overlay.tsx
+++ b/atoms/src/components/overlay/blaze-overlay.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop } from '@stencil/core';
+import { Component, Method, Prop, State } from '@stencil/core';
 
 @Component({
   tag: 'blaze-overlay'
@@ -6,12 +6,46 @@ import { Component, Prop } from '@stencil/core';
 export class Overlay {
 
   @Prop() open: boolean;
+  @Prop() dismissible: boolean = false;
+  @Prop() transparent: boolean = false;
+  @Prop() fullpage: boolean = false;
+  @State() _isOpen: boolean = false;
+
+  componentWillLoad() {
+    this._isOpen = this.open;
+  }
+
+  @Method()
+  show() {
+    this._isOpen = true;
+  }
+
+  @Method()
+  close() {
+    this._isOpen = false;
+  }
+
+  @Method()
+  isOpen() {
+    return this._isOpen;
+  }
+
+  dismiss() {
+    if (this.dismissible) {
+      this.close();
+    }
+  }
 
   render() {
-    const isOpenClass = this.open ? 'c-overlay--visible' : '';
+    const openClass = this._isOpen ? 'c-overlay--visible' : '';
+    const dismissibleClass = this.dismissible ? 'c-overlay--dismissible' : '';
+    const transparentClass = this.transparent ? 'c-overlay--transparent' : '';
+    const fullpageClass = this.fullpage ? 'c-overlay--fullpage' : '';
 
     return (
-      <div aria-hidden class={`c-overlay ${isOpenClass}`}></div>
+      <div aria-hidden
+           onClick={() => this.dismiss()}
+           class={`c-overlay ${openClass} ${dismissibleClass} ${transparentClass} ${fullpageClass}`}></div>
     );
   }
 }

--- a/atoms/src/index.html
+++ b/atoms/src/index.html
@@ -250,6 +250,15 @@
         </blaze-modal>
       </blaze-tab>
 
+      <blaze-tab header="Overlay">
+        <button type="button" onclick="javascript:showModal('#overlay-dismissible')" class="c-button c-button--brand">Open dismissible Overlay</button>
+        <button type="button" onclick="javascript:showModal('#overlay-transparent-dismissible')" class="c-button c-button--brand">Open transparent dismissible Overlay</button>
+        <button type="button" onclick="javascript:showModal('#overlay-fullpage-dismissible')" class="c-button c-button--brand">Open fullpage dismissible Overlay</button>
+        <blaze-overlay id="overlay-dismissible" dismissible></blaze-overlay>
+        <blaze-overlay id="overlay-transparent-dismissible" transparent dismissible></blaze-overlay>
+        <blaze-overlay id="overlay-fullpage-dismissible" fullpage dismissible></blaze-overlay>
+      </blaze-tab>
+
       <blaze-tab header="Pagination">
         <blaze-pagination pages="15"></blaze-pagination>
       </blaze-tab>


### PR DESCRIPTION
Related to #194 

*Tests are missing.*

The existing atoms that use `blaze-overlay` either need to be adjusted to use the public methods to open/close the overlay **or** the overlay itself needs to be structured differently than the other atoms.

Meaning: No `_isOpen` state but a mutable `open` property, so the overlay can close itself **and** the way for example the [`blaze-drawer`](https://github.com/BlazeUI/blaze/blob/master/atoms/src/components/drawer/blaze-drawer.tsx#L42) closes the overlay (by changing the `open` property) still works the same.